### PR TITLE
Complete logEvent fix (% in values), second-resolution log timestamps, visible trigger-wait text

### DIFF
--- a/fMRI_task.m
+++ b/fMRI_task.m
@@ -209,6 +209,7 @@ try
     %% TRIGGER WAIT
     
     % Display a message on screen while waiting for the scanner trigger
+    Screen('FillRect', win, gray);
     DrawFormattedText(win, params.triggerWaitText, 'center', 'center', black);
     
     % Display the message and log it

--- a/utils/createLogFile.m
+++ b/utils/createLogFile.m
@@ -42,6 +42,6 @@ logFileName = strcat(dateTimeStr, '_', runInfo, '_task-', params.taskName, '_log
 logFilePathName = fullfile(in.resDir, logFileName);
 
 % Initiate the log file by creating it in write mode
-logFile = fopen(logFilePathName, 'a');
+logFile = fopen(logFilePathName, 'w');
 
 end

--- a/utils/dateTimeStr.m
+++ b/utils/dateTimeStr.m
@@ -12,7 +12,7 @@ function dateTimeString = dateTimeStr()
 %   Tim Maniquet [27/3/24]
 
 % Extract the current date and time
-dateTimeString = char(datetime('now', 'Format', 'yyyy-MM-dd-HH-mm'));
+dateTimeString = char(datetime('now', 'Format', 'yyyy-MM-dd-HH-mm-ss'));
 
 
 end

--- a/utils/logEvent.m
+++ b/utils/logEvent.m
@@ -64,10 +64,10 @@ function logEvent(logFile, eventType, eventName, dateTime, expOnset, actualOnset
 % If the log file is not the command window
 if ~(logFile == 1)
     % Log in the external log file
-    fprintf(logFile, logMessage);
+    fprintf(logFile, '%s', logMessage);
 end
 
 % In both cases, log in the command window
-fprintf(1, logMessage);
+fprintf(1, '%s', logMessage);
 
 end


### PR DESCRIPTION
Three logging-robustness fixes on top of merged #6. (1) logEvent: print with fprintf(fid,'%s',logMessage) — #6 restored the logMessage variable but fprintf still used it as the format string, so values containing % (the MRI trigger key name is 5%, logged every volume) corrupted/merged log lines. (2) dateTimeStr second-resolution + createLogFile opens 'w' (minute-resolution + 'a' concatenated same-minute runs). (3) trigger-wait text drawn on a gray fill (was black-on-black, invisible). Scanner keycodes 5%/3#/4$ unchanged. Each change tested before commit.