### PR TITLE
Add promptSubjectRun: validated subject/run entry (DRY)

### DIFF
--- a/fMRI_task.m
+++ b/fMRI_task.m
@@ -78,22 +78,9 @@ params = parseParameterFile('parameters.txt', fmriMode);
 
 %% USER INPUT: SUBJECT & RUN NUMBER
 
-% Declare subject number and decide on the run to start from
-if debugMode == true
-    % Default values for subject & run number in debug mode
-    answer = {'99', '1'};
-else
-    % Else if in actual experiment mode
-    prompt = {'subject number', sprintf('Run number (out of %d)', params.numRuns)};
-    % Define empty default answers
-    def = {'', ''};
-    % Collect user input
-    answer = inputdlg(prompt,'',1,def);
-end
-
-% Store the subject & run number in the 'input' structure
-in.subNum = str2double(answer{1});
-in.runNum = str2double(answer{2});
+% Get and validate the subject & run numbers (input dialog in experiment mode,
+% defaults in debug mode). Single source of truth: promptSubjectRun.
+[in.subNum, in.runNum] = promptSubjectRun(params, debugMode);
 
 % Save a timestamp in the input parameters
 in.timestamp = string(datetime('now', 'Format', 'yyyy-MM-dd_HHmmss'));
@@ -115,7 +102,7 @@ end
 % Prepares a subject- and run-specific directory to store outputs
 
 % Make a directory name with subject number if it doesn't exist yet
-in.resDir = fullfile(pwd, 'data', ['sub-' zeroFill(answer{1}, 2)]);
+in.resDir = fullfile(pwd, 'data', ['sub-' zeroFill(in.subNum, 2)]);
 
 % Check if the results directory exists & if we're not in debug mode
 if exist(in.resDir, 'dir') == 0 && debugMode == false

--- a/utils/promptSubjectRun.m
+++ b/utils/promptSubjectRun.m
@@ -1,0 +1,48 @@
+function [subNum, runNum] = promptSubjectRun(params, debugMode)
+% PROMPTSUBJECTRUN Get subject and run numbers (interactive or defaults).
+%
+%   In debug mode, returns defaults (subNum=99, runNum=1).
+%   In production, shows input dialog for experimenter to enter values.
+%
+% Inputs:
+%   params    - Must include numRuns field for validation prompt
+%   debugMode - If true, skip dialog and use defaults
+%
+% Outputs:
+%   subNum - Subject number (integer)
+%   runNum - Run number (integer)
+%
+% Example:
+%   [subNum, runNum] = promptSubjectRun(params, false);  % Show dialog
+%   [subNum, runNum] = promptSubjectRun(params, true);   % Use defaults
+%
+% Author: Andrea Costantino
+
+if debugMode
+    % Use defaults for quick testing
+    answer = {'99', '1'};
+else
+    % Show input dialog for experimenter
+    prompt = {'Subject number', sprintf('Run number (out of %d)', params.numRuns)};
+    answer = inputdlg(prompt, 'Session Info', 1, {'', ''});
+
+    % Handle cancel button
+    if isempty(answer)
+        error('Session:Cancelled', 'Session setup cancelled by user.');
+    end
+end
+
+% Convert to numbers
+subNum = str2double(answer{1});
+runNum = str2double(answer{2});
+
+% Validate
+if isnan(subNum) || isnan(runNum)
+    error('Session:InvalidInput', 'Subject and run numbers must be numeric.');
+end
+
+if runNum < 1 || runNum > params.numRuns
+    error('Session:InvalidRun', 'Run number must be between 1 and %d.', params.numRuns);
+end
+
+end


### PR DESCRIPTION
Replaces the inline inputdlg block in fMRI_task.m with a single promptSubjectRun helper that returns validated subject and run numbers. It handles dialog cancel, non-numeric input, and out-of-range run numbers, preventing run-NaN output files. Keeps subject/run handling DRY (one source of truth); resDir now uses in.subNum. Tested: debug returns [99 1]; invalid run range raises Session:InvalidRun; fMRI_task.m and promptSubjectRun.m lint clean.