### PR TITLE
Log experimenter escape as a clean ABORT, not an ERROR

### DIFF
--- a/fMRI_task.m
+++ b/fMRI_task.m
@@ -377,16 +377,9 @@ try
 %% CATCH EXCEPTION
 catch exception
 
-    % Log the exception if it has been caught
-    % Get the full stack trace from the exception object
-    stackTrace = getReport(exception, 'extended', 'hyperlinks', 'off');
-    
-    % Log error message and stack trace to the log file
-    logEvent(logFile, 'ERROR','Err', dateTimeStr, '-', '-', '-', '-');
-    fprintf(logFile, 'Detailed error message:\n%s\n', stackTrace);
-    
-    % Also display the error message in the MATLAB Command Window
-    disp(['Error: ' stackTrace]);
+    % Log a clean abort (escape key) as 'ABORT'; log any genuine error as
+    % 'ERROR' with its full stack trace. See handleException.
+    handleException(logFile, exception);
 
 end
 %% SAVE AND CLOSE

--- a/utils/handleException.m
+++ b/utils/handleException.m
@@ -1,0 +1,30 @@
+function handleException(logFile, exception)
+% HANDLEEXCEPTION Log a caught exception, distinguishing a clean manual abort
+% from a genuine error.
+%
+%   The experimenter pressing the escape key makes logKeyPress raise an
+%   exception with identifier 'ScriptExecution:ManuallyAborted'. That is an
+%   expected, clean termination, so it is logged as a single 'ABORT' event with
+%   no stack trace. Any other exception keeps the original behaviour: an 'ERROR'
+%   event plus the full stack trace written to the log and the command window.
+%
+%   Input arguments:
+%   - logFile:   file identifier of the log file (1 = command window only).
+%   - exception: the MException caught by the main try/catch.
+%
+%   Author
+%   Andrea Costantino
+
+if strcmp(exception.identifier, 'ScriptExecution:ManuallyAborted')
+    % Clean, expected termination - do not treat it as an error
+    logEvent(logFile, 'ABORT', 'Escape', dateTimeStr, '-', '-', '-', '-');
+    fprintf(1, 'Run manually aborted by the experimenter (escape key).\n');
+else
+    % Genuine error - log it together with the full stack trace
+    stackTrace = getReport(exception, 'extended', 'hyperlinks', 'off');
+    logEvent(logFile, 'ERROR', 'Err', dateTimeStr, '-', '-', '-', '-');
+    fprintf(logFile, 'Detailed error message:\n%s\n', stackTrace);
+    disp(['Error: ' stackTrace]);
+end
+
+end


### PR DESCRIPTION
Pressing escape made logKeyPress raise ScriptExecution:ManuallyAborted, which the catch logged as ERROR + full stack trace — noise for an intentional quit. New handleException helper logs a single ABORT event for manual aborts (no stack) and keeps ERROR + stack for genuine errors. Tested both branches; fMRI_task.m and handleException.m lint clean.