### PR TITLE
Convert degrees to pixels using params screen geometry (DRY)

### DIFF
--- a/fMRI_task.m
+++ b/fMRI_task.m
@@ -153,7 +153,7 @@ try
     Screen(win, 'fillrect', gray);
     
     % Store the pixels per degree value for use in the setup
-    in.PPD = convertVisualUnits(1, 'deg', 'px');
+    in.PPD = degToPix(1, params);
    
     %% RUN-SPECIFIC PARAMETERS
     

--- a/utils/degToPix.m
+++ b/utils/degToPix.m
@@ -1,0 +1,37 @@
+function px = degToPix(deg, params)
+% DEGTOPIX Convert a size in degrees of visual angle to pixels using the screen
+% geometry declared in params, instead of convertVisualUnits' hardcoded defaults.
+%
+%   This is the single place that maps visual degrees to pixels, so the
+%   conversion follows the actual screen distance and width selected for the
+%   current mode (MRI vs PC) rather than always assuming the scanner values.
+%
+%   Notes:
+%   - Presentation resolution defaults to 1920x1080 (the scanner display) and
+%     can be overridden via params.scrResX / params.scrResY. Resize happens
+%     before the window opens, so the resolution is taken from params, not the
+%     live window.
+%   - Square pixels are assumed (physical height derived from width and
+%     resolution); for the reference geometry this yields exactly the same
+%     pixels as the previous hardcoded defaults.
+%
+%   Inputs:
+%   - deg:    size(s) in degrees of visual angle (scalar or array).
+%   - params: must contain scrDist (mm) and scrWidth (mm); optional scrResX/scrResY.
+%
+%   Author
+%   Andrea Costantino
+
+% Presentation resolution (scanner default; overridable via params)
+resX = 1920;
+resY = 1080;
+if isfield(params, 'scrResX') && ~isempty(params.scrResX), resX = params.scrResX; end
+if isfield(params, 'scrResY') && ~isempty(params.scrResY), resY = params.scrResY; end
+
+% Physical screen height (mm) from the declared width, assuming square pixels
+sizeYmm = params.scrWidth * resY / resX;
+
+% Delegate the actual conversion, now driven by params geometry
+px = convertVisualUnits(deg, 'deg', 'px', params.scrDist, resX, resY, params.scrWidth, sizeYmm);
+
+end

--- a/utils/displayFixation.m
+++ b/utils/displayFixation.m
@@ -44,7 +44,7 @@ if strcmp(params.fixType, 'round')
     rectSize = [outElement midElement centerElement];
     
     % Convert the element sizes from to pixels
-    fixSize = round(convertVisualUnits(rectSize, 'deg', 'px')); 
+    fixSize = round(degToPix(rectSize, params)); 
     
     % Initialize an array to store rectangle coordinates for drawing the fixation point
     fixRect = zeros(4, length(fixSize));
@@ -75,7 +75,7 @@ elseif strcmp(params.fixType, 'cross')
     fixCol = in.black;
     
     % Define the size and position of the fixation cross (in pixels)
-    crossLength = round(convertVisualUnits(params.fixSize, 'deg', 'px')); % Length of each arm of the cross
+    crossLength = round(degToPix(params.fixSize, params)); % Length of each arm of the cross
     crossWidth = round(crossLength/10); % Width of the cross lines
     centerX = winRect(3) / 2;
     centerY = winRect(4) / 2;

--- a/utils/resizeStim.m
+++ b/utils/resizeStim.m
@@ -54,8 +54,8 @@ end
 % Check the resize mode
 if strcmpi(params.resizeMode, 'visualUnits')
     % Convert visual degrees to pixels
-    output_width_pixels = convertVisualUnits(width, 'deg', 'px');
-    output_height_pixels = convertVisualUnits(height, 'deg', 'px');
+    output_width_pixels = degToPix(width, params);
+    output_height_pixels = degToPix(height, params);
 elseif strcmpi(params.resizeMode, 'pixelSize')
     output_width_pixels = width;
     output_height_pixels = height;


### PR DESCRIPTION
deg->px conversions used convertVisualUnits(x,'deg','px'), ignoring params and always assuming scanner geometry (630mm/340mm). New degToPix(deg, params) helper is the single mapping, driven by params.scrDist/scrWidth (resolution defaults to 1920x1080, overridable via params.scrResX/Y). Reference scanner geometry gives identical pixels (real experiment unchanged); PC/debug geometry is now correct. Regression-tested (reference == old defaults across 0.5-12 deg; PC differs and matches explicit geometry); all touched files lint clean.